### PR TITLE
gsyscSimulator.cc: Delete sc_start() function call in stop branch

### DIFF
--- a/gsysSimulator.cc
+++ b/gsysSimulator.cc
@@ -269,7 +269,6 @@
     {
       // do value-Save for being able to detect changes in the last step
       (new gsysMain())->getRegModule()->saveAllPortValues();
-      sc_start();
       aktStep++;   
       hardStop = true;
       setCaption( tr( "Simulator - steps done: " ).append(asChar(aktStep)) );


### PR DESCRIPTION
Bugfix: sc_start() function call causes endless loop.

Signed-off-by: andrewerner <andre.werner-w2m@ruhr-uni-bochum.de>